### PR TITLE
Added payload tracking for ease of debugging

### DIFF
--- a/src/ApnsService.php
+++ b/src/ApnsService.php
@@ -41,6 +41,11 @@ class ApnsService
      */
     private $errors;
 
+    /**
+     * @var array
+     */
+    private $payloads;
+
 
     /**
      * AppleNotificationService constructor.
@@ -66,8 +71,9 @@ class ApnsService
     {
         if ($devices->count() <= 0) {
             return [
-                'errors' => [],
-                'updates' => []
+                'errors'   => [],
+                'updates'  => [],
+                'payloads' => [],
             ];
         }
 
@@ -88,7 +94,6 @@ class ApnsService
             try {
                 $properties = join(',', array_merge(['title', 'message'], array_keys($device->metadata)));
                 $message = new \ApnsPHP_Message_Custom($device->token);
-                
 
                 $message->setCustomIdentifier($device->hash . '::' . (++$this->seq));
                 $message->setText($device->message);
@@ -107,6 +112,9 @@ class ApnsService
                 if ( ! empty($device->badge)) {
                     $message->setBadge($device->badge);
                 }
+
+                // Track payloads
+                $this->payloads[] = $message->getPayload();
 
                 $apns->add($message);
             } catch (\Exception $e) {
@@ -149,8 +157,9 @@ class ApnsService
         $apns = null;
 
         return [
-            'errors' => $this->errors,
-            'updates' => []
+            'payloads' => $this->payloads,
+            'errors'   => $this->errors,
+            'updates'  => []
         ];
     }
 

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -95,8 +95,9 @@ class Notification
         });
 
         $results = [
-            'errors' => [],
-            'updates' => [],
+            'errors'   => [],
+            'updates'  => [],
+            'payloads' => []
         ];
 
         $this->mergeResults($results, $this->pushApns($apns));
@@ -123,8 +124,9 @@ class Notification
     {
         if (empty($devices) || $devices->isEmpty()) {
             return [
-                'errors' => [],
-                'updates' => []
+                'errors'   => [],
+                'updates'  => [],
+                'payloads' => []
             ];
         }
 
@@ -155,8 +157,9 @@ class Notification
     {
         if (empty($devices) || $devices->isEmpty()) {
             return [
-                'errors' => [],
-                'updates' => []
+                'errors'   => [],
+                'updates'  => [],
+                'payloads' => []
             ];
         }
 
@@ -178,8 +181,9 @@ class Notification
         $chunks = $devices->chunk((int)config('push.chunk', 100));
 
         $results = [
-            'errors' => [],
-            'updates' => []
+            'errors'   => [],
+            'updates'  => [],
+            'payloads' => []
         ];
 
         foreach ($chunks as $chunk) {
@@ -198,8 +202,9 @@ class Notification
      */
     private function mergeResults(&$results, $result)
     {
-        $results['errors'] = array_merge($results['errors'], $result['errors']);
-        $results['updates'] = array_merge($results['updates'], $result['updates']);
+        $results['errors']   = array_merge($results['errors'],   $result['errors']);
+        $results['updates']  = array_merge($results['updates'],  $result['updates']);
+        $results['payloads'] = array_merge($results['payloads'], $result['payloads']);
     }
 
 


### PR DESCRIPTION
When trying to implement Unicode characters (Emoji) I found the underlying APNs library escaping to be troublesome. Debugging was a pain without being able to easily see the true JSON payloads being generated. Now the return array from the Notification->send() method will contain a copy of each JSON payload generated. 